### PR TITLE
Update check-log4j.sh

### DIFF
--- a/src/check-log4j.sh
+++ b/src/check-log4j.sh
@@ -430,6 +430,7 @@ verdict() {
 	echo
 	if [ -z "${SUSPECT_JARS}" -a -z "${SUSPECT_PACKAGES}" -a -z "${SUSPECT_CLASSES}" ]; then
 		log "No obvious indicators of vulnerability to CVE-2021-44228 / CVE-2021-45046 found."
+		exit 0
 	fi
 
 	if [ -n "${SUSPECT_JARS}" -a x"${FIX}" = x"yes" ]; then


### PR DESCRIPTION
Added zero return-code in condition "No obvious indicators of vulnerability ... found" . It was present before 319fc357f4d7db26c876e374656c315c46c8a827

It's useful used into ansible playbooks to get the hosts which are not vulnerable to be marked as ok and green highlighted.

Thanks


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
